### PR TITLE
Add "Group with Obsidian's copy path" toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- "Group with Obsidian's copy path" setting (off by default). When on, every
+  enabled custom format is appended into Obsidian's native **Copy path**
+  submenu alongside built-in entries like *as Obsidian URL* and *from vault
+  folder*, instead of living inside the plugin's own **Copy path as** submenu.
+  Uses the public `MenuItem.setSection` API with section id `info.copy`; no
+  internal Obsidian APIs are touched.
+
 ## [2.2.1] - 2026-05-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You can copy from three places:
 - **Right-click inside an open note.** The formats act on that note, and the heading-aware formats link to the heading your cursor is in.
 - **Command palette** (`Ctrl/Cmd+P`): type `Copy:` and pick a format. It acts on the active file.
 
-In the right-click menu, the enabled formats sit inside a **Copy path as** submenu to keep the menu tidy. Pick the format you want and the result lands on your clipboard. You can pin individual formats to the root menu, or turn the submenu off entirely, in settings.
+In the right-click menu, the enabled formats sit inside a **Copy path as** submenu to keep the menu tidy. Pick the format you want and the result lands on your clipboard. You can pin individual formats to the root menu, or turn the submenu off entirely, in settings. There is also an option to fold every format into Obsidian's native **Copy path** submenu instead, so all path-copy choices (the built-in ones and yours) live in one place.
 
 Out of the box four formats are enabled: Relative Linux/macOS path, Relative Windows path, Obsidian URL, and Markdown link. Open the settings to enable the others or add your own.
 
@@ -161,6 +161,7 @@ Global options:
 - **Markdown link format**: wiki-style (`[[filename]]`) or standard Markdown (`[filename](path)`). Used by the `<markdown-link>` token.
 - **Notify when a token could not be resolved**: show a notice when a desktop-only or editor-only token is left blank.
 - **Group formats under a submenu**: nest every format inside one **Copy path as** right-click submenu (on by default). Turn it off to put every enabled format directly at the root menu, the way 2.1.x worked.
+- **Group with Obsidian's copy path**: instead of the plugin's own submenu, append every format inside Obsidian's native **Copy path** submenu, alongside the built-in entries like *as Obsidian URL* and *from vault folder*. When this is on, the **Group formats under a submenu** option above is ignored.
 
 Everything else is per format, in the Custom formats list.
 

--- a/main.ts
+++ b/main.ts
@@ -31,6 +31,7 @@ interface PathCopySettings {
 	markdownLinkFormat: MarkdownLinkFormat;
 	warnOnUnresolvedTokens: boolean;
 	useSubmenu: boolean;
+	groupWithNativeCopyPath: boolean;
 	customFormats: CustomFormat[];
 	settingsVersion: number;
 }
@@ -40,9 +41,22 @@ const DEFAULT_SETTINGS: PathCopySettings = {
 	markdownLinkFormat: 'wiki-style',
 	warnOnUnresolvedTokens: true,
 	useSubmenu: true,
+	groupWithNativeCopyPath: false,
 	customFormats: [],
 	settingsVersion: 0
 }
+
+// Obsidian's section id for items that render inside the native "Copy path"
+// virtual submenu (alongside "as Obsidian URL", "from vault folder",
+// "from system root"). The dotted name is a section-collapse convention:
+// Obsidian groups every MenuItem sharing this section into one labeled
+// submenu in the parent menu. Items added with this section render as
+// children of the "Copy path" submenu using only public-API setSection.
+// Verified empirically against Obsidian's file-menu items (Obsidian 1.6+);
+// if a future release renames the section, items render in their own
+// section instead of throwing.
+//
+const NATIVE_COPY_PATH_SECTION = 'info.copy';
 
 // Curated set of menu-relevant icons offered in the per-format icon picker.
 const ICON_CHOICES: string[] = [
@@ -110,6 +124,9 @@ export default class ShellPathCopyPlugin extends Plugin {
 			if (typeof raw.useSubmenu === 'boolean') {
 				this.settings.useSubmenu = raw.useSubmenu;
 			}
+			if (typeof raw.groupWithNativeCopyPath === 'boolean') {
+				this.settings.groupWithNativeCopyPath = raw.groupWithNativeCopyPath;
+			}
 			if (typeof raw.settingsVersion === 'number') {
 				this.settings.settingsVersion = raw.settingsVersion;
 			}
@@ -163,12 +180,28 @@ export default class ShellPathCopyPlugin extends Plugin {
 
 	// Adds the enabled custom-format items to a context menu. `editor` is passed
 	// from the in-document right-click so the cursor's heading and line resolve.
-	// When useSubmenu is on, items live inside a 'Copy path as' submenu; pinned
-	// items also appear at the root. The menu is rebuilt on every right-click,
-	// so changes here take effect without a reload.
+	// Three layouts, picked by settings:
+	//   - groupWithNativeCopyPath on: assign each format the same section id
+	//     ('info.copy') Obsidian uses for its native "as Obsidian URL" /
+	//     "from vault folder" / "from system root" items. Obsidian collapses
+	//     every item sharing that section into one virtual "Copy path"
+	//     submenu, so the formats render as children of that submenu using
+	//     only public-API setSection.
+	//   - useSubmenu on (default): formats live inside a "Copy path as" submenu;
+	//     formats with pinToRoot also appear at the menu root.
+	//   - both off: every format appears flat at the menu root.
+	// The menu is rebuilt on every right-click, so changes take effect without a
+	// reload.
 	private addPathCopyMenuItems(menu: Menu, file: TAbstractFile, editor?: Editor) {
 		const visible = this.settings.customFormats.filter((fmt) => fmt.enabled && fmt.showInMenu);
 		if (visible.length === 0) {
+			return;
+		}
+
+		if (this.settings.groupWithNativeCopyPath) {
+			for (const fmt of visible) {
+				this.addFormatMenuItem(menu, fmt, file, editor, NATIVE_COPY_PATH_SECTION);
+			}
 			return;
 		}
 
@@ -177,7 +210,7 @@ export default class ShellPathCopyPlugin extends Plugin {
 		const useSubmenu = this.settings.useSubmenu;
 
 		for (const fmt of pickRootFormats(visible, useSubmenu)) {
-			this.addFormatMenuItem(menu, fmt, file, editor, true);
+			this.addFormatMenuItem(menu, fmt, file, editor, 'shell-path-copy');
 		}
 
 		if (useSubmenu) {
@@ -188,17 +221,18 @@ export default class ShellPathCopyPlugin extends Plugin {
 					.setSection('shell-path-copy');
 				const submenu = parent.setSubmenu();
 				for (const fmt of visible) {
-					this.addFormatMenuItem(submenu, fmt, file, editor, false);
+					this.addFormatMenuItem(submenu, fmt, file, editor, null);
 				}
 			});
 		}
 	}
 
-	// Adds a single format as an item on the given menu. `inRootSection` controls
-	// the section assignment: root items use the 'shell-path-copy' section so
-	// they group with other plugin items; submenu items omit the section because
-	// the submenu itself already groups them.
-	private addFormatMenuItem(menu: Menu, fmt: CustomFormat, file: TAbstractFile, editor: Editor | undefined, inRootSection: boolean) {
+	// Adds a single format as an item on the given menu. `section` chooses the
+	// MenuItem.setSection target: a string assigns the named section (root-level
+	// items group with other items in that section, separated by Obsidian's own
+	// dividers); null omits setSection (used for submenu children, where the
+	// submenu itself already does the grouping).
+	private addFormatMenuItem(menu: Menu, fmt: CustomFormat, file: TAbstractFile, editor: Editor | undefined, section: string | null) {
 		const formatId = fmt.id;
 		menu.addItem((item) => {
 			item
@@ -207,8 +241,8 @@ export default class ShellPathCopyPlugin extends Plugin {
 				.onClick(async () => {
 					await this.copyCustomFormat(formatId, file, editor);
 				});
-			if (inRootSection) {
-				item.setSection('shell-path-copy');
+			if (section !== null) {
+				item.setSection(section);
 			}
 		});
 	}
@@ -428,12 +462,25 @@ class ShellPathCopySettingTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName('Group formats under a submenu')
-			.setDesc('Nest every format inside one right-click submenu. Pin individual formats below to also show them at the root menu.')
+			.setDesc('Nest every format inside one right-click submenu. Pin individual formats below to also show them at the root menu. Ignored when "group with Obsidian\'s copy path" is on.')
 			.addToggle(toggle => toggle
 				.setValue(this.plugin.settings.useSubmenu)
+				.setDisabled(this.plugin.settings.groupWithNativeCopyPath)
 				.onChange(async (value) => {
 					this.plugin.settings.useSubmenu = value;
 					await this.plugin.saveSettings();
+				}));
+
+		new Setting(containerEl)
+			.setName("Group with Obsidian's copy path")
+			.setDesc("Place every enabled format inside Obsidian's native copy path submenu, alongside built-in entries like 'as Obsidian URL' and 'from vault folder'. The plugin's own 'copy path as' submenu is hidden when this is on.")
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.groupWithNativeCopyPath)
+				.onChange(async (value) => {
+					this.plugin.settings.groupWithNativeCopyPath = value;
+					await this.plugin.saveSettings();
+					// Re-render so the dependent submenu toggle updates its disabled state.
+					this.display();
 				}));
 
 		this.renderCustomFormatsSection(containerEl);


### PR DESCRIPTION
## Summary

Adds a new global setting that places every enabled custom format inside Obsidian's native **Copy path** submenu (alongside built-in entries like *as Obsidian URL* and *from vault folder*), instead of inside the plugin's own **Copy path as** submenu.

Closes the follow-up reported on [#15](https://github.com/ckelsoe/obsidian-shell-path-copy/issues/15) where users want the formats nested under Obsidian's native item.

## Implementation

One constant: `setSection('info.copy')` on each format menu item. Obsidian's section-collapse convention groups every menu item sharing that section id into one virtual submenu titled "Copy path". No internal Obsidian APIs are touched.

When the new toggle is on, the plugin's own "Copy path as" submenu is skipped and the existing "Group formats under a submenu" setting is greyed out.

## Test plan

- [ ] Reload plugin in test vault
- [ ] Settings → toggle "Group with Obsidian's copy path" on
- [ ] Right-click a file in file explorer: formats appear inside Obsidian's native Copy path submenu, after the built-in entries
- [ ] Each format copies the expected string
- [ ] Toggle off: formats return to the "Copy path as" submenu (or root, depending on the other toggle)
- [ ] In-document right-click (no native Copy path in editor-menu): formats still appear via section grouping